### PR TITLE
fix: include empty request body in refresh-tokens api

### DIFF
--- a/frontend/src/features/auth/authApi.js
+++ b/frontend/src/features/auth/authApi.js
@@ -60,7 +60,8 @@ export const getUserApi = async () => {
         return res.data;
     } catch (error) {
         try {
-            const res = await axios.post(`${URL}/refresh-tokens`, { withCredentials: true });
+            await axios.post(`${URL}/refresh-tokens`, {}, { withCredentials: true });
+            const res = await axios.get(`${URL}/get-user`, { withCredentials: true });
             return res.data;
         } catch (error) {
             const message = "Unauthorized Access";


### PR DESCRIPTION
included missing empty request body in /refresh-tokens api call